### PR TITLE
Ghost URL Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
  * [Next.js 7](https://nextjs.org/blog/next-7)
  * [Using Next.js with Github Pages](https://hipstersmoothie.com/blog/next-pages/)
  * [Next.js E-commerce Tutorial: Quick Shopping Cart Integration](https://snipcart.com/blog/next-js-ecommerce-tutorial)
- * [Working with Ghost and Next.js](https://ghost.org/docs/api/v2/nextjs/)
+ * [Working with Ghost and Next.js](https://ghost.org/docs/api/nextjs/)
  * [Using Tailwind CSS with Next.js](https://statickit.com/guides/next-js-tailwind)
 
 ## Boilerplates


### PR DESCRIPTION
Our documentation uses a specific URL pattern to ensure people are directed to the latest version of our docs, hence the removal of `v2/` in this case. Thanks!