### PR TITLE
Add next-connect to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@
 * [Next PurgeCSS](https://github.com/lucleray/next-purgecss) - Easily integrate [Purgecss](https://www.purgecss.com/), which helps you remove unused CSS from your bundle.
 * [Next PWA](https://github.com/shadowwalker/next-pwa) - Zero config PWA plugin for Next.js with workbox
 * [flow-middleware](https://github.com/piglovesyou/flow-middleware) - Run any of Express middlewares on Next.js without polluting native objects.
+* [next-connect](https://github.com/hoangvvo/next-connect) - The Express/Connect-compatible router and middleware layer for Next.js.
 
 ## Apps
 * [NextJS GOT](https://github.com/auth0-blog/nextjs-got) - Simple Next.js application that showcases Game of Thrones Characters.


### PR DESCRIPTION
next-connect is a method routing and middleware layer for Next.js. Powered by trouter. This allows the use of Express middleware without a custom server.

(Recreated #120 since fork is lost)