### PR TITLE
adding next-deploy under extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@
 * [next-connect](https://github.com/hoangvvo/next-connect) - The Express/Connect-compatible router and middleware layer for Next.js.
 * [next-img](https://github.com/humaans/next-img/) - a plugin for embedding optimized images with ease.
 * [next-auth](https://github.com/iaincollins/next-auth) - Easy authentication for Next.js and Serverless
+* [next-deploy](https://github.com/lone-cloud/next-deploy) - 🚀 Effortless deployment to AWS and GitHub Pages.
 
 ## Apps
 * [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.


### PR DESCRIPTION
I semi-recently released https://github.com/lone-cloud/next-deploy which allows for effortless deploys to github pages and AWS (serverless).