### PR TITLE
Add Nextconf 2020 playlist to videos categegory

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@
 * [Next.js Crash Course - Server Side React](https://www.youtube.com/watch?v=IkOVe40Sy0U)
 * [Mastering Next.js](https://masteringnextjs.com/) - 50+ lesson video course for building applications with Next.js and React.
 * [Next.js Tutorial](https://www.youtube.com/watch?v=7J4iL1HDshQ&list=PLYSZyzpwBEWSQsrukurP09ksi49H9Yj40) - In depth Next.js tutorials.
+* [Next.js Conf 2020](https://www.youtube.com/playlist?list=PLBnKlKpPeagnT2Cmv4giCbosfrbKnuYTD) - All the videos from the 2020 Next.js conference
 
 ## Newsletters
 


### PR DESCRIPTION
The playlist is from the official Vercel youtube channel. https://www.youtube.com/playlist?list=PLBnKlKpPeagnT2Cmv4giCbosfrbKnuYTD
Looks like most of the videos, if not all are uploaded to the channel.