### PR TITLE
Add next-image-trace-loader to Extensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 * [next-deploy](https://github.com/lone-cloud/next-deploy) - 🚀 Effortless deployment to AWS and GitHub Pages.
 * [next-joi](https://github.com/codecoolture/next-joi) - Validate Next.js API Routes, with _joi_.
 * [next-transpile-modules](https://github.com/martpie/next-transpile-modules) - Next.js plugin to transpile code from node_modules. Useful for monorepos.
+* [next-image-trace-loader](https://github.com/BrandonKlotz/next-image-trace-loader) - Next.js plugin to display traced SVGs outlines of images while they load.
 
 ## Apps
 * [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.


### PR DESCRIPTION
Add `next-image-trace-loader` plugin to Extensions.
- https://github.com/BrandonKlotz/next-image-trace-loader

> A plugin that displays traced SVGs outlines of images while they load.