### PR TITLE
Add next-password-protect to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@
 * [next-joi](https://github.com/codecoolture/next-joi) - Validate Next.js API Routes, with _joi_.
 * [next-transpile-modules](https://github.com/martpie/next-transpile-modules) - Next.js plugin to transpile code from node_modules. Useful for monorepos.
 * [Destack for Next.js](https://github.com/liveduo/destack) - Next.js extension to visually build landing pages locally.
+* [next-password-protect](https://github.com/storyofams/next-password-protect) - Password protect your Next.js projects.
 
 ## Apps
 * [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.


### PR DESCRIPTION
[next-password-protect](https://github.com/storyofams/next-password-protect) contains helpers to add a password prompt to a Next.js project.