### PR TITLE
Added Materio Free MUI React Next.js Admin Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 * [Nextatic](https://github.com/tancredi/nextatic) - 🌍 Static website multi-language boilerplate with user-editable pages and navigation using Netlify CMS + Next.js + SCSS + Typescript.
 * [Sitemap generator for NextJS & StrAPI](https://github.com/stovv/next-strapi-sitemap) - 🦾 An additional server on express that runs alongside nextjs and regenerates sitemap ( with index sitemap ) and robots.txt files on request from STR API.
 * [superplate](https://github.com/pankod/superplate) - superplate creates Next.js app in seconds with TypeScript, styled-components, SWR, Storybook, and 35+ plugin.
+* [Materio Free MUI React Next.js Admin Template](https://github.com/themeselection/materio-mui-react-nextjs-admin-template-free) - Most Powerful & Comprehensive Free MUI React NextJS Admin Dashboard Template built for developers.
 
 ## Extensions
 * [Next universal language detector](https://github.com/UnlyEd/universal-language-detector) - Language detector that works universally (browser + server) - Meant to be used with a universal framework, such as Next.js [DEMO](https://universal-language-detector.now.sh/)


### PR DESCRIPTION
## Materio Free MUI React Next. js Admin Template

Materio Free MUI React Next. js Admin Template is the most developer-friendly & highly customizable template based on [MUI](https://mui.com/)  & [ Next. js](https://nextjs.org/). Besides, it is available in both Typescript and JavaScript versions.

If you’re a developer looking for an MUI React Admin Template that is developer-friendly, rich with features, and highly customizable, look no further than Materio MUI React Next. js admin template. 

GitHub Repo: https://github.com/themeselection/materio-mui-react-nextjs-admin-template-free
Demo: https://demos.themeselection.com/materio-mui-react-nextjs-admin-template-free/