### PR TITLE
Added Next.js Tailwind Starter to Boilerplates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 * [Nextatic](https://github.com/tancredi/nextatic) - 🌍 Static website multi-language boilerplate with user-editable pages and navigation using Netlify CMS + Next.js + SCSS + Typescript.
 * [Sitemap generator for NextJS & StrAPI](https://github.com/stovv/next-strapi-sitemap) - 🦾 An additional server on express that runs alongside nextjs and regenerates sitemap ( with index sitemap ) and robots.txt files on request from STR API.
 * [superplate](https://github.com/pankod/superplate) - superplate creates Next.js app in seconds with TypeScript, styled-components, SWR, Storybook, and 35+ plugin.
+* [Next.js Tailwind Starter](https://github.com/dvzrd/next-tailwind-starter) - A Next.js Starter with custom tailwind components, Dark and Light theme, a Google Sheets contact form, and a basic MDX blog. Primed and ready for quickly prototyping and deploying static SEO-friendly websites.
 
 ## Extensions
 * [Next universal language detector](https://github.com/UnlyEd/universal-language-detector) - Language detector that works universally (browser + server) - Meant to be used with a universal framework, such as Next.js [DEMO](https://universal-language-detector.now.sh/)


### PR DESCRIPTION
## Next.js Tailwind Starter

A Next.js boilerplate based on [Next-js-Boilerplate](https://github.com/ixartz/Next-js-Boilerplate) - a very recent codebase. The difference is that Next.js Tailwind Starter comes with custom tailwindcss components (as the name implies) and has a additional features and example pages that will help you build a site relatively quickly.

Github repo: https://github.com/dvzrd/next-tailwind-starter
