### PR TITLE
Added next with inlang - i18n tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Runtime Environment Variables for Next.js](https://www.npmjs.com/package/@cuww/runtime-env) – Stop configuring ENV variables in CI/CD, use a cloud-native approach.
 - [next-google-tag-manager](https://github.com/XD2Sketch/next-google-tag-manager) – Easily add Google Tag Manager to Next 13 and up.
 - [next-api-decorators](https://github.com/storyofams/next-api-decorators) - Decorators to create typed Next.js API routes, with easy request validation and transformation.
+- [Next with inlang](https://inlang.com/c/nextjs) - ⚛️ [inlang's](https://github.com/opral/monorepo/tree/main/inlang) i18n tools for App & Pages Router.
 
 
 ## Apps


### PR DESCRIPTION
## Next with inlang

inlang is an i18n framework. The link (https://inlang.com/c/nextjs) provides the best way to get started with the ecosystem for nextjs users. 

![image](https://github.com/unicodeveloper/awesome-nextjs/assets/58360188/9f1bb9ef-95d7-486c-b6ca-2426b8945b8b)

Github repo: https://github.com/opral/monorepo/tree/main/inlang