### PR TITLE
Add ParaglideJS to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Runtime Environment Variables for Next.js](https://www.npmjs.com/package/@cuww/runtime-env) – Stop configuring ENV variables in CI/CD, use a cloud-native approach.
 - [next-google-tag-manager](https://github.com/XD2Sketch/next-google-tag-manager) – Easily add Google Tag Manager to Next 13 and up.
 - [next-api-decorators](https://github.com/storyofams/next-api-decorators) - Decorators to create typed Next.js API routes, with easy request validation and transformation.
-
+- [paraglide-js](https://inlang.com/m/osslbuzt/library-inlang-paraglideJsAdapterNextJs) - A tiny, type-safe i18n library that only ships messages that are used in client-components.
 
 ## Apps
 


### PR DESCRIPTION
ParaglideJS is a tiny i18n library with fully type-safe messages (including params) that only ships messages that are used in client-components to the client. 

Link to Documentation: https://inlang.com/m/osslbuzt/library-inlang-paraglideJsAdapterNextJs

> (Technically it's paraglide + the paraglide-next-adapter, but that title seems too long)