### PR TITLE
Add Next-Shadcn-Intl-Template to Boilerplates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [NextJS Chargebee Subscription](https://github.com/bharathvaj-ganesan/chargebee-saas-stack) - A Chargebee focused T3 Stack that integrates User Subscriptions, Authentication and Testing. Driven by Prisma ORM.
 - [Next.js Enterprise](https://github.com/Blazity/next-enterprise) - enterprise-grade boilerplate for high-performance, maintainable apps. Built with Tailwind CSS, RadixUI, TypeScript and more.
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
+- [Next-Shadcn-Intl-Template](https://github.com/your-username/next-shadcn-intl-template) - 🌐 A clean and minimal Next.js starter template with Tailwind CSS, ShadcnUI, and NextIntl. Pre-configured for i18n without extra features like auth or payments.
 
 ## Extensions
 


### PR DESCRIPTION
This commit adds the Next-Shadcn-Intl-Template project to the Boilerplates section of the awesome-nextjs list. This template provides a clean and minimal starter setup for Next.js projects with Tailwind CSS, ShadcnUI, and NextIntl.

Key features:
- Pre-configured i18n setup
- Integration of ShadcnUI components
- Clean architecture without additional features like authentication or payment systems

Project link: https://github.com/LeonZeng919/next-shadcn-intl-template

This addition offers value to developers looking for a streamlined, internationalization-ready Next.js boilerplate without the complexity of additional features. It aligns with the list's focus on high-quality, purpose-specific Next.js resources.