### PR TITLE
Add Vercel community

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 - [GitHub](https://github.com/vercel/next.js)
 - [GitHub discussions for Next.js](https://github.com/vercel/next.js/discussions)
+- [Vercel Community](https://vercel.community/)
 
 ## Essentials
 


### PR DESCRIPTION
Hi, thanks for creating this. I've proposed an addition to the community section - Vercel maintains an official community site that is a great resource for getting help with Next.js issues and questions. It's not a formal support channel, but Vercel engineers do hang out and answer questions from time to time. It would be great to make this more widely known so folks can get help when they need it.