### PR TITLE
Add SEO Next.js Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [NextJS Chargebee Subscription](https://github.com/bharathvaj-ganesan/chargebee-saas-stack) - A Chargebee focused T3 Stack that integrates User Subscriptions, Authentication and Testing. Driven by Prisma ORM.
 - [Next.js Enterprise](https://github.com/Blazity/next-enterprise) - enterprise-grade boilerplate for high-performance, maintainable apps. Built with Tailwind CSS, RadixUI, TypeScript and more.
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
+- [SEO Next.js Starter](https://github.com/wangrunlin/seo-nextjs-starter) - A simple and easy-to-use starter template for building SEO optimized Next.js applications with best practices and performance in mind.
 
 ## Extensions
 


### PR DESCRIPTION
- [SEO Next.js Starter GitHub Repo](https://github.com/wangrunlin/seo-nextjs-starter)
- [Live Demo SEO Next.js Starter](https://seo-nextjs-starter.vercel.app)