### PR TITLE
Add next-rspack

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Runtime Environment Variables for Next.js](https://www.npmjs.com/package/@cuww/runtime-env) – Stop configuring ENV variables in CI/CD, use a cloud-native approach.
 - [next-google-tag-manager](https://github.com/XD2Sketch/next-google-tag-manager) – Easily add Google Tag Manager to Next 13 and up.
 - [next-api-decorators](https://github.com/storyofams/next-api-decorators) - Decorators to create typed Next.js API routes, with easy request validation and transformation.
-
+- [next-rspack](https://rspack.dev/guide/tech/next) - Use [Rspack](https://github.com/web-infra-dev/rspack) as the bundler for Next.js.
 
 ## Apps
 


### PR DESCRIPTION
[next-rspack](https://www.npmjs.com/package/next-rspack) is a community-driven plugin that enables Next.js projects to use Rspack as the bundler (experimental).

Announcement:

- https://nextjs.org/blog/next-15-3#community-support-for-rspack-experimental
- https://rspack.dev/blog/rspack-next-partner

Source code:

- https://github.com/vercel/next.js/tree/canary/packages/next-rspack

How to use:

- https://rspack.dev/guide/tech/next