### PR TITLE
Add Craft CMS starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 ## Contents
 
-- [Awesome Next.js ](#awesome-nextjs--)
+- [Awesome Next.js  ](#awesome-nextjs--)
   - [Contents](#contents)
   - [Community](#community)
   - [Essentials](#essentials)
@@ -81,6 +81,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 ## Boilerplates
 
+- [Craft CMS + Next.js Starter](https://github.com/craftcms/starter-next) - A minimal, production-ready headless starter that integrates Next.js with Craft CMS, featuring GraphQL API integration, pagination, and live preview functionality with draft sharing.
 - [Kaminari Template](https://kaminari.vercel.app/) - Power packed Next.js and Tailwind CSS template. Built with developer experience in mind. Contains Husky, CommitLint, Prettier, Eslint etc. configs. ✨
 - [Next.js, Strapi Portfolio Starter](https://github.com/PictureElement/nextjs-strapi-portfolio-starter) – ⚡️ A modern portfolio starter with Next.js, Strapi, and Tailwind CSS, featuring automated XML sitemap, JSON-LD schemas, OpenGraph metadata, and a contact form with spam protection.
 - [Next.js Static Blog](https://www.cosmicjs.com/apps/nextjs-static-blog) - Next.js static blog powered by the Cosmic Headless CMS


### PR DESCRIPTION
# Add Craft CMS Next.js Starter

I'd like to add the official Craft CMS + Next.js starter project to the Awesome Next.js list.

This production-ready starter provides:
- Clean separation of frontend (Next.js) and backend (Craft CMS) code
- Integration with Craft CMS's built-in GraphQL API
- Blog, category feeds, and guestbook with clean pagination
- Live preview functionality with support for shareable draft URLs
- GraphQL mutations demonstrated through a guestbook example
- DDEV setup for streamlined local development

The starter is officially maintained by Pixel & Tonic, the makers of Craft CMS, and serves as an excellent starting point for developers looking to create headless applications with Next.js and Craft CMS.