### PR TITLE
Add Oaysus to Extensions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Runtime Environment Variables for Next.js](https://www.npmjs.com/package/@cuww/runtime-env) – Stop configuring ENV variables in CI/CD, use a cloud-native approach.
 - [next-google-tag-manager](https://github.com/XD2Sketch/next-google-tag-manager) – Easily add Google Tag Manager to Next 13 and up.
 - [next-api-decorators](https://github.com/storyofams/next-api-decorators) - Decorators to create typed Next.js API routes, with easy request validation and transformation.
+- [Oaysus](https://github.com/oaysus/cli) - Visual page builder for Next.js. Build React components and push with one CLI command. Marketing teams create pages visually.
 
 ## Apps
 


### PR DESCRIPTION
## Summary

Adding [Oaysus](https://github.com/oaysus/cli) to the Extensions section.

Oaysus is a visual page builder that lets developers build React components and push them with a single CLI command. Marketing teams can then create and publish pages visually without touching code.

## Checklist

- [x] Entry follows the existing format
- [ ] - [x] Added in alphabetical order within the Extensions section
- [ ] - [x] Link points to the GitHub repository
- [ ] - [x] Description is concise and relevant to Next.js users