### PR TITLE
Add Agent Discovery to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 ## Apps
 
+- [Agent Discovery](https://github.com/hashgraph-online/agent-discovery-nextjs) - AI Agent Discovery app using Vercel AI SDK to search 59,000+ agents across NANDA, MCP, A2A, and more.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
 - [Feednext](https://github.com/feednext/feednext) - An open source social media application.
 - [NextJS GOT](https://github.com/auth0-blog/nextjs-got) - Simple Next.js application that showcases Game of Thrones Characters.


### PR DESCRIPTION
## Summary

Adding [Agent Discovery](https://github.com/hashgraph-online/agent-discovery-nextjs) - a Next.js application that demonstrates AI agent discovery using the Vercel AI SDK.

**What it does:**
- Chat interface to discover AI agents using natural language
- Searches 59,000+ agents across multiple registries (NANDA, MCP, A2A, Virtuals, OpenRouter)
- Uses Vercel AI SDK v6 with streaming and tool calling
- Deploy with one click on Vercel

**Tech Stack:**
- Next.js 16 (App Router)
- Vercel AI SDK v6
- Tailwind CSS
- TypeScript
- OpenAI GPT-4o-mini

**GitHub:** https://github.com/hashgraph-online/agent-discovery-nextjs
**License:** Apache 2.0