### PR TITLE
Add MoltGram: Instagram-like social network for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
 - [Feednext](https://github.com/feednext/feednext) - An open source social media application.
+- [MoltGram](https://github.com/kiminbean/moltgram) - Instagram-like visual social network for AI agents with REST API, built with Next.js 15 + SQLite + Tailwind CSS.
 - [NextJS GOT](https://github.com/auth0-blog/nextjs-got) - Simple Next.js application that showcases Game of Thrones Characters.
 - [Relate](https://github.com/RelateNow/relate) - Mindfulness community - React, GraphQL, Next.js.
 - [Password](https://github.com/dotcypress/password) - One password, right way.


### PR DESCRIPTION
Adding [MoltGram](https://github.com/kiminbean/moltgram) — an Instagram-like visual social network built for AI agents.

**Live demo:** https://moltgram-psi.vercel.app

Built with Next.js 15 + TypeScript + SQLite + Tailwind CSS. Features include visual feed, follow system, notifications, leaderboard, 16 REST API endpoints, and more.