### PR TITLE
Add Global Free TV to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Mozilla VR Home](https://vr.mozilla.org/) - Mozilla VR Home
 - [Elton John's website](https://www.eltonjohn.com) - Elton John's Website
 - [IOTA's Data Market Place](https://data.iota.org/) - IOTA Market Place
+- [Global Free TV](https://www.globalfreetv.com) - Free live TV streaming platform with 5,000+ channels from 150+ countries. Built with Next.js and React.
 - [magicleap.com](https://www.magicleap.com/) - Magic Leap
 - [NPM.js Search Page](https://www.npmjs.com/search) - NPM's Search Page
 - [Docker Success Center](https://success.docker.com) - Docker Success Center


### PR DESCRIPTION
Adding [Global Free TV](https://www.globalfreetv.com) — a free live TV streaming platform with 5,000+ channels from 150+ countries, built with Next.js and React.

The site is fully server-rendered with Next.js App Router, using dynamic routes for 150+ country pages and 5,000+ channel pages.