### PR TITLE
Add VisaCanvas to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [VisaCanvas](https://visacanvas.com/) - AI-powered EB1A and NIW visa eligibility assessment tool that evaluates candidates against USCIS extraordinary ability criteria.
 
 ## Books
 


### PR DESCRIPTION
Add [VisaCanvas](https://visacanvas.com/) to the Apps section.

VisaCanvas is an AI-powered EB1A and NIW visa eligibility assessment tool built with Next.js that evaluates candidates against USCIS extraordinary ability criteria.