### PR TITLE
Add LaunchFast - Next.js SaaS Boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 ## Boilerplates
 
 - [Kaminari Template](https://kaminari.vercel.app/) - Power packed Next.js and Tailwind CSS template. Built with developer experience in mind. Contains Husky, CommitLint, Prettier, Eslint etc. configs. ✨
+- [LaunchFast](https://github.com/Wittlesus/launchfast-starter) - Production-ready Next.js 16 SaaS boilerplate with NextAuth v5, Stripe payments, Prisma 6 ORM, Claude AI integration, and Resend email. Ship your startup in hours with TypeScript, TailwindCSS, and dark mode built-in.
 - [Next.js, Strapi Portfolio Starter](https://github.com/PictureElement/nextjs-strapi-portfolio-starter) – ⚡️ A modern portfolio starter with Next.js, Strapi, and Tailwind CSS, featuring automated XML sitemap, JSON-LD schemas, OpenGraph metadata, and a contact form with spam protection.
 - [Next.js Static Blog](https://www.cosmicjs.com/apps/nextjs-static-blog) - Next.js static blog powered by the Cosmic Headless CMS
 - [NextJS Headless CMS Powered Blog Starter](https://github.com/ButterCMS/react-cms-blog-with-next-js)


### PR DESCRIPTION
Adding LaunchFast, a production-ready Next.js SaaS boilerplate with auth (NextAuth.js v5), Stripe billing, AI integration (Anthropic), Prisma ORM, and Resend email.

- [GitHub Repository](https://github.com/Wittlesus/launchfast-starter)
- [Live Demo](https://wittlesus.github.io/launchfast-starter/)

Placed in the Boilerplates section in alphabetical order.