### PR TITLE
Add Wolfcha to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [Wolfcha](https://github.com/oil-oil/wolfcha) - AI-powered Werewolf social deduction game where every player is controlled by top LLMs like DeepSeek, Qwen, and Gemini.
 
 ## Books
 


### PR DESCRIPTION
[Wolfcha](https://github.com/oil-oil/wolfcha) is an open-source AI-powered Werewolf (Mafia) social deduction game built with Next.js 16, TypeScript, Tailwind CSS, and Jotai. Multiple top AI models (DeepSeek, Qwen, Gemini, etc.) compete in logical deduction and verbal sparring. Features bilingual support (EN/CN), voice TTS, game analysis, and retro-styled UI with animations.

Live: https://wolf-cha.com