### PR TITLE
Add Frontman to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Vercel AI SDK](https://github.com/vercel/ai) - The AI Toolkit for TypeScript. Build AI-powered applications with React, Next.js, Vue, Svelte, and Node.js.
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit) - React UI + elegant infrastructure for AI Copilots, AI chatbots, and in-app AI agents in your Next.js apps.
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
+- [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.
 
 ## Apps
 


### PR DESCRIPTION
## Add Frontman

[Frontman](https://github.com/frontman-ai/frontman) is an open-source AI coding agent that lives in your browser. Click any element in your running Next.js app, describe changes in plain English, and get real source code edits with hot reload.

It ships with first-class Next.js support via `@frontman-ai/nextjs`.

https://github.com/frontman-ai/frontman