### PR TITLE
Add next-single-file to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Vercel AI SDK](https://github.com/vercel/ai) - The AI Toolkit for TypeScript. Build AI-powered applications with React, Next.js, Vue, Svelte, and Node.js.
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit) - React UI + elegant infrastructure for AI Copilots, AI chatbots, and in-app AI agents in your Next.js apps.
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
+- [next-single-file](https://github.com/simples-tools/next-single-file) - Transform a Next.js static export into a single, self-contained HTML file with hash-based routing.
 
 ## Apps
 


### PR DESCRIPTION
## Summary

- Add [next-single-file](https://github.com/simples-tools/next-single-file) - a CLI tool that transforms a Next.js static export into a single, self-contained HTML file with hash-based routing

## Features

- Self-contained output (zero external dependencies)
- Hash-based routing for client-side navigation
- All assets (JS, CSS, fonts, images) inlined as base64 data URIs
- Supports Geist fonts, Turbopack, and modern Next.js features
- Regex-based, lightning fast (~392ms for test app)