### PR TITLE
Add Vercel SEO Audit to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Vercel AI SDK](https://github.com/vercel/ai) - The AI Toolkit for TypeScript. Build AI-powered applications with React, Next.js, Vue, Svelte, and Node.js.
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit) - React UI + elegant infrastructure for AI Copilots, AI chatbots, and in-app AI agents in your Next.js apps.
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
+- [Vercel SEO Audit](https://github.com/JosephDoUrden/vercel-seo-audit) - CLI tool that diagnoses SEO and indexing issues specific to Next.js and Vercel deployments.
 
 ## Apps
 


### PR DESCRIPTION
[Vercel SEO Audit](https://github.com/JosephDoUrden/vercel-seo-audit) is a CLI tool that diagnoses SEO and indexing issues specific to Next.js and Vercel deployments.

It detects common Next.js pitfalls like 308 trailing-slash redirect traps, middleware rewrite issues, missing robots.txt/sitemap, canonical mismatches, structured data validation, security headers, and more.

- Published on npm: [vercel-seo-audit](https://www.npmjs.com/package/vercel-seo-audit)
- MIT licensed
- 50+ stars on GitHub

I added it to the **Extensions** section as it extends the Next.js development workflow with SEO auditing capabilities.