### PR TITLE
Add ogimg.xyz to Extensions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [next-api-decorators](https://github.com/storyofams/next-api-decorators) - Decorators to create typed Next.js API routes, with easy request validation and transformation.
 - [Vercel AI SDK](https://github.com/vercel/ai) - The AI Toolkit for TypeScript. Build AI-powered applications with React, Next.js, Vue, Svelte, and Node.js.
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit) - React UI + elegant infrastructure for AI Copilots, AI chatbots, and in-app AI agents in your Next.js apps.
+- [ogimg.xyz](https://ogimg.xyz) - OG image generation API with 10 templates, background patterns, and URL auto-fetch. Built with Next.js + Satori on Vercel Edge.
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
 
 ## Apps


### PR DESCRIPTION
Adds [ogimg.xyz](https://ogimg.xyz/) to the **Extensions** section, near other SEO and OG-related tools (Next SEO, Next-Sitemap, ShotOG).

ogimg.xyz is an API for generating Open Graph images — built with Next.js and Satori on Vercel Edge. It generates 1200×630 PNG social preview images in under 200ms from 10 customizable templates.

- GET/POST API with URL auto-fetch mode
- 10 templates, 10 background patterns, custom colors and branding
- Free tier: 50 images/month