### PR TITLE
Add prodlint — production readiness for vibe-coded Next.js apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit) - React UI + elegant infrastructure for AI Copilots, AI chatbots, and in-app AI agents in your Next.js apps.
 - [ogimg.xyz](https://ogimg.xyz) - OG image generation API with 10 templates, background patterns, and URL auto-fetch. Built with Next.js + Satori on Vercel Edge.
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
-- [prodlint](https://github.com/prodlint/prodlint) - The linter for vibe-coded Next.js apps. Catches hallucinated imports, missing auth, server action validation, and 49 other production bugs AI coding tools write. Zero config.
+- [prodlint](https://github.com/prodlint/prodlint) - Production readiness for vibe-coded Next.js apps. 52 checks for hallucinated imports, missing auth, server action validation, and more. Zero config.
 
 ## Apps
 


### PR DESCRIPTION
## What is prodlint?

[prodlint](https://github.com/prodlint/prodlint) is a production readiness tool for vibe-coded apps — a zero-config static analysis CLI that checks whether AI-generated Next.js code is ready to ship.

52 checks across security, reliability, performance, and AI quality. Flags hallucinated imports, missing auth on API routes, server action validation, insecure cookies, and more — things ESLint misses.

```bash
npx prodlint
```

- **npm**: https://www.npmjs.com/package/prodlint
- **Website**: https://prodlint.com
- **License**: MIT

Added to the Extensions section.