### PR TITLE
Add DevToolBox - Free Online Developer Tools (Next.js App)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [DevToolBox](https://viadreams.cc) - 129+ free online developer tools (JSON formatter, Base64 encoder, JWT decoder, regex tester, hash generator, and more). Built with Next.js, 100% client-side processing, open source.
 
 ## Books
 


### PR DESCRIPTION
## Add DevToolBox - Free Online Developer Tools

Hi! I'd like to add [DevToolBox](https://viadreams.cc) to the **Apps** section of this awesome list.

### What is DevToolBox?

DevToolBox is a free, open-source collection of **129+ online developer tools** built with **Next.js**, including:

- JSON formatter/validator
- Base64 encoder/decoder
- JWT decoder
- Regex tester
- Hash generator (MD5, SHA-1, SHA-256, etc.)
- UUID generator
- Color converter
- And 120+ more tools

### Why it fits this list

- **Built with Next.js** and TypeScript
- **100% client-side** processing — no data sent to servers (privacy-first)
- Open source on GitHub
- No signup required, completely free
- Supports **15 languages**
- 112 developer guides and tutorials
- Deployed on Vercel

**Website:** https://viadreams.cc
**GitHub:** https://github.com/arenasbob2024-cell/devtoolbox

Thank you for maintaining this awesome list!