### PR TITLE
Add modal-layout-component to Extensions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [UseSIWE](https://github.com/random-bits-studio/use-siwe) - React hooks and Next.js API routes that make it super easy to add Sign-In with Ethereum to your app.
 - [Runtime Environment Variables for Next.js](https://www.npmjs.com/package/@cuww/runtime-env) – Stop configuring ENV variables in CI/CD, use a cloud-native approach.
 - [next-google-tag-manager](https://github.com/XD2Sketch/next-google-tag-manager) – Easily add Google Tag Manager to Next 13 and up.
+- [modal-layout-component](https://github.com/ArtemZhyto/Modal-layout-component) - Lightweight and accessible headless modal layout for Next.js with focus trapping.
 - [next-api-decorators](https://github.com/storyofams/next-api-decorators) - Decorators to create typed Next.js API routes, with easy request validation and transformation.
 - [Vercel AI SDK](https://github.com/vercel/ai) - The AI Toolkit for TypeScript. Build AI-powered applications with React, Next.js, Vue, Svelte, and Node.js.
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit) - React UI + elegant infrastructure for AI Copilots, AI chatbots, and in-app AI agents in your Next.js apps.


### PR DESCRIPTION
Hi! I'd like to add `modal-layout-component` to the Extensions section. 

It's a headless, zero-dependency modal engine specifically built to handle the "hard parts" of Next.js client components:
- Proper focus trapping (WAI-ARIA).
- Body scroll locking (preserving scroll position).
- CSS-driven exit animations.

Alphabetical order maintained. Thanks!