### PR TITLE
Add ShipAI.today to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [NextJS Chargebee Subscription](https://github.com/bharathvaj-ganesan/chargebee-saas-stack) - A Chargebee focused T3 Stack that integrates User Subscriptions, Authentication and Testing. Driven by Prisma ORM.
 - [Next.js Enterprise](https://github.com/Blazity/next-enterprise) - enterprise-grade boilerplate for high-performance, maintainable apps. Built with Tailwind CSS, RadixUI, TypeScript and more.
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
+- [ShipAI.today](https://shipai.today/) - Next.js AI SaaS boilerplate with auth and billing.
 
 ## Extensions
 


### PR DESCRIPTION
## Summary
Add ShipAI.today to the Boilerplates section.

## Boilerplate
- Name: ShipAI.today
- Website: https://shipai.today/
- Tagline: AI SaaS Boilerplate and Next.js Launch Template
- Pricing: 299 USD one-time, unlimited projects
- Affiliate Program: Yes
