### PR TITLE
Add Agentic React to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [NextJS Chargebee Subscription](https://github.com/bharathvaj-ganesan/chargebee-saas-stack) - A Chargebee focused T3 Stack that integrates User Subscriptions, Authentication and Testing. Driven by Prisma ORM.
 - [Next.js Enterprise](https://github.com/Blazity/next-enterprise) - enterprise-grade boilerplate for high-performance, maintainable apps. Built with Tailwind CSS, RadixUI, TypeScript and more.
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
+- [Agentic React](https://github.com/iscale-llc/agentic-react-nextjs-shadcn) - GitHub template for agent-testable SaaS apps with Next.js 16 + shadcn/ui + Neon Postgres + Drizzle ORM. Includes agent-browser e2e test harness using accessibility tree navigation and strict jsx-a11y linting.
 
 ## Extensions
 


### PR DESCRIPTION
Adds [Agentic React](https://github.com/iscale-llc/agentic-react-nextjs-shadcn) to the Boilerplates section.

A GitHub template for building agent-testable SaaS apps with Next.js 16 + shadcn/ui + Neon Postgres + Drizzle ORM. Includes an agent-browser e2e test harness that lets AI agents navigate and test apps using the accessibility tree, plus strict jsx-a11y linting (30 a11y rules at error level).

https://github.com/iscale-llc/agentic-react-nextjs-shadcn