### PR TITLE
Add Kaiforge Lite to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [NextJS Chargebee Subscription](https://github.com/bharathvaj-ganesan/chargebee-saas-stack) - A Chargebee focused T3 Stack that integrates User Subscriptions, Authentication and Testing. Driven by Prisma ORM.
 - [Next.js Enterprise](https://github.com/Blazity/next-enterprise) - enterprise-grade boilerplate for high-performance, maintainable apps. Built with Tailwind CSS, RadixUI, TypeScript and more.
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
+- [Kaiforge Lite](https://github.com/DevxiaLabs/kaiforge-lite) - Free and open-source Next.js admin dashboard template with Tailwind CSS, dark mode, and multiple color themes.
 
 ## Extensions
 


### PR DESCRIPTION
- [Kaiforge Lite](https://github.com/DevxiaLabs/kaiforge-lite) - Free and open-source Next.js admin dashboard template with Tailwind CSS, dark mode, and multiple color themes.

**What it is:** A free, MIT-licensed Next.js 14 + Tailwind CSS admin dashboard template with 5 color themes, dark/light mode, responsive layout, and 10+ pages.

**Links:**
- Repository: https://github.com/DevxiaLabs/kaiforge-lite
- Live Demo: https://lite.kaiforge.dev
- License: MIT