### PR TITLE
Add SubstanceWiki to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 ## Apps
 
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.
+- [SubstanceWiki](https://github.com/yagcioglutoprak/substance_wiki) - Open-source encyclopedia of psychoactive substances with dosage guides, drug interactions, effects, and harm reduction. Built with Next.js 16, PostgreSQL, Tailwind CSS.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
 - [Feednext](https://github.com/feednext/feednext) - An open source social media application.
 - [NextJS GOT](https://github.com/auth0-blog/nextjs-got) - Simple Next.js application that showcases Game of Thrones Characters.


### PR DESCRIPTION
Added [SubstanceWiki](https://github.com/yagcioglutoprak/substance_wiki) to the Apps section.

SubstanceWiki is a comprehensive, open-source encyclopedia of psychoactive substances built with **Next.js 16** (App Router, Turbopack), PostgreSQL via Prisma, and Tailwind CSS.

Features:
- 381 substance profiles with dosage guides and duration timelines
- Drug interaction safety checker (14,967 combinations)
- 240+ catalogued subjective effects
- Dynamic OG images via @vercel/og
- JSON-LD structured data on every page type
- Programmatic SEO with comparison and combo pages

**Live:** https://substancewiki.org  
**License:** Open source