### PR TITLE
Add Pharos AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [Pharos AI](https://github.com/Juliusolsson05/pharos-ai) - Open-source real-time intelligence dashboard for geopolitical conflict tracking with interactive maps, OSINT feeds, and actor dossiers.
 
 ## Books
 


### PR DESCRIPTION
Pharos AI is an open-source real-time intelligence dashboard for geopolitical conflict tracking.

- Live: https://conflicts.app
- Repo: https://github.com/Juliusolsson05/pharos-ai
- License: AGPL-3.0-only
- Stack: Next.js 16, React 19, PostgreSQL, DeckGL, MapLibre
- Self-hostable via Docker

It aggregates 30+ OSINT feeds (Reuters, AP, Press TV, TASS, etc.), provides interactive geospatial visualization, actor dossiers, event timelines, and daily intelligence briefs.