### PR TITLE
Add Shoof Aflam to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [Shoof Aflam](https://shoofaflam.tv) - Free Arabic streaming guide to find where to watch 14,000+ movies and series across 18 platforms in the Arab world. Built with Next.js 16, static export, React 19.
 
 ## Books
 


### PR DESCRIPTION
## Summary

- Added [Shoof Aflam](https://shoofaflam.tv) to the Apps section
- Shoof Aflam is a free Arabic streaming guide to find where to watch 14,000+ movies and series across 18 platforms in the Arab world
- Built with Next.js 16, static export, React 19

## Details

Shoof Aflam helps Arabic-speaking users discover where to stream movies and TV series across 18 platforms (Netflix, Shahid, OSN+, etc.) in the Arab world. The site is fully statically exported, supports Arabic RTL layout, and includes Schema.org structured data for SEO.

Website: https://shoofaflam.tv