### PR TITLE
Add FIM Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
+- [FIM Agent](https://github.com/fim-ai/fim-agent) - AI-powered Connector Hub with a Next.js + shadcn/ui portal frontend. Features agent management, connector configuration, knowledge base, and real-time chat with SSE streaming.
 - [Feednext](https://github.com/feednext/feednext) - An open source social media application.
 - [NextJS GOT](https://github.com/auth0-blog/nextjs-got) - Simple Next.js application that showcases Game of Thrones Characters.
 - [Relate](https://github.com/RelateNow/relate) - Mindfulness community - React, GraphQL, Next.js.


### PR DESCRIPTION
## Add FIM Agent

[FIM Agent](https://github.com/fim-ai/fim-agent) is an AI-powered Connector Hub with a Next.js portal frontend built with shadcn/ui.

**Next.js frontend features:**
- App Router with server/client component separation
- shadcn/ui component library
- next-intl for i18n (English + Chinese)
- Real-time chat with SSE streaming
- Agent management, connector configuration, knowledge base UI

**Links:** [GitHub](https://github.com/fim-ai/fim-agent) | [Website](https://agent.fim.ai) | [Docs](https://docs.fim.ai)