### PR TITLE
Add Agent Factory to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [Agent Factory](https://github.com/shuanbao0/agent-factory) - Self-contained multi-agent collaboration platform with 64 AI agent templates and Dashboard UI. Built with Next.js 14, TypeScript, Tailwind CSS.
 
 ## Books
 


### PR DESCRIPTION
## Summary

- Adds [Agent Factory](https://github.com/shuanbao0/agent-factory) to the **Apps** section
- Agent Factory is an open-source (GPL-3.0) self-contained multi-agent collaboration platform with 64 AI agent templates and a Dashboard UI
- Built with Next.js 14, TypeScript, and Tailwind CSS

Thank you for maintaining this awesome list!

🤖 Generated with [Claude Code](https://claude.com/claude-code)