### PR TITLE
Add A11y Starter Kit boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Next.js Enterprise](https://github.com/Blazity/next-enterprise) - enterprise-grade boilerplate for high-performance, maintainable apps. Built with Tailwind CSS, RadixUI, TypeScript and more.
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
 - [Kaiforge Lite](https://github.com/DevxiaLabs/kaiforge-lite) - Free and open-source Next.js admin dashboard template with Tailwind CSS, dark mode, and multiple color themes.
+- [A11y Starter Kit](https://github.com/thefrontkit/a11y-starter-kit-code) - Accessibility-first Next.js starter kit with best practices for building inclusive web apps. Demo: https://a11y-starter-kit.vercel.app/
 
 ## Extensions
 


### PR DESCRIPTION
  - Adds A11y Starter Kit to the Boilerplates section

  About A11y Starter Kit

  An accessibility-first Next.js starter kit that
  provides best practices for building inclusive web
  apps. It helps developers ship accessible
  applications from day one rather than retrofitting
  accessibility later.

  Live Demo: https://a11y-starter-kit.vercel.app/

  Checklist

  - Added to the correct section (Boilerplates)
  - Follows the existing list format
  - Project is open source and hosted on GitHub
  - Includes a live demo link

  ---
  Want me to adjust anything in this description?
