### PR TITLE
Add OpenHive — open-source Slack alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 ## Apps
 
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.
+- [OpenHive](https://github.com/arseneHuot/openhive) - Open-source, self-hosted Slack alternative built with Next.js 14 App Router, Supabase, Zustand, and LiveKit. Features channels, DMs, threads, reactions, file uploads, and video/audio calls.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
 - [FIM Agent](https://github.com/fim-ai/fim-agent) - AI-powered Connector Hub with a Next.js + shadcn/ui portal frontend. Features agent management, connector configuration, knowledge base, and real-time chat with SSE streaming.
 - [Feednext](https://github.com/feednext/feednext) - An open source social media application.


### PR DESCRIPTION
## What is OpenHive?

[OpenHive](https://github.com/arseneHuot/openhive) is a fully open-source, self-hosted team messaging platform — a Slack alternative built with Next.js 14 App Router.

## Next.js Features Used

- **App Router** — Full use of the Next.js 14 App Router with layouts, route groups
- **API Routes** — LiveKit token generation, webhook handling, setup wizard
- **Server Components** — Optimized rendering
- **Dynamic Routes** — Workspace and channel routing

## Key Features

- Channels, DMs, threaded conversations
- @mentions, emoji reactions, file uploads
- Pinned messages, read receipts
- Video/audio calls with screen sharing (LiveKit)
- Setup wizard that auto-provisions 23 database tables

## Tech Stack

Next.js 14 + TypeScript + Tailwind CSS + shadcn/ui + Supabase + Zustand + LiveKit

## Links

- **GitHub**: https://github.com/arseneHuot/openhive
- **License**: MIT