### PR TITLE
Add SkillsHub to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [SkillsHub](https://github.com/ComeOnOliver/skillshub) - AI agent skills registry with 5,300+ skills. One API call to find the right skill for any task. Built with Next.js, TypeScript, and Drizzle ORM.
 
 ## Books
 


### PR DESCRIPTION
Added [SkillsHub](https://github.com/ComeOnOliver/skillshub) — an open-source AI agent skills registry with 5,300+ skills, built with Next.js, TypeScript, and Drizzle ORM.

It provides a unified API to search and discover the right skill for any task using natural language queries. Useful for developers building AI agent systems.

Thank you for maintaining this awesome list! 🙏