### PR TITLE
Add @aeorank/next to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Next Plugin Graphql](https://github.com/lfades/next-plugin-graphql) - Next.js plugin for .graphql and .gql files using graphql-tag
 - [Next With Apollo](https://github.com/lfades/next-with-apollo) - Apollo Graphql integration for Next.js
 - [Next SEO](https://github.com/garmeeh/next-seo) - SEO made easy for Next.js
+- [@aeorank/next](https://github.com/vinpatel/aeorank) - Drop-in AEO (Answer Engine Optimization) plugin for Next.js — generates llms.txt, schema.json, and more AI-readable files at build time.
 - [Next-Sitemap](https://github.com/iamvishnusankar/next-sitemap) - Sitemap generator for Next.js
 - [Next UserAgent](https://github.com/tokuda109/next-useragent) - UserAgent parser for Next.js
 - [Next Cookie](https://github.com/tokuda109/next-cookie) - Cookie serializer and deserializer library for Next.js.


### PR DESCRIPTION
## Summary
- Adds [@aeorank/next](https://github.com/vinpatel/aeorank) to the **Extensions** section
- Drop-in AEO (Answer Engine Optimization) plugin for Next.js — generates `llms.txt`, `schema.json`, and 6 more AI-readable files at build time
- Published on npm: https://www.npmjs.com/package/@aeorank/next