### PR TITLE
Add NextFs — F# bindings for Next.js App Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
 - [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
+- [NextFs](https://github.com/Neftedollar/Next.fs) - Write Next.js App Router apps in F# via Fable. Full API coverage: components, routing, server actions, metadata, OG images, fonts, and instrumentation.
 
 ## Apps
 


### PR DESCRIPTION
[NextFs](https://github.com/Neftedollar/Next.fs) lets you write Next.js App Router applications in F# via [Fable](https://fable.io).

Full API coverage: components, routing, server actions, metadata, OG image generation, fonts, cache directives, and instrumentation — all in idiomatic F#.

- [NuGet](https://www.nuget.org/packages/NextFs) (v1.0.0)
- [Documentation](https://neftedollar.github.io/Next.fs/)
- MIT license