### PR TITLE
Add thesvg to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
 
 ## Apps
+- [thesvg](https://thesvg.org) - Open source SVG icon library with 5,600+ brand and cloud icons. Built with Next.js 15 App Router, Tailwind CSS, and Fuse.js search. [Source](https://github.com/glincker/thesvg)
 
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
 
 ## Apps
-- [thesvg](https://thesvg.org) - Open source SVG icon library with 5,600+ brand and cloud icons. Built with Next.js 15 App Router, Tailwind CSS, and Fuse.js search. [Source](https://github.com/glincker/thesvg)
+- [thesvg](https://thesvg.org) - Open source SVG icon library with 5,600+ brand and cloud icons. Built with Next.js 15 App Router, Tailwind CSS, and Fuse.js search (GitHub: https://github.com/glincker/thesvg).
 
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 ## Apps
 - [thesvg](https://thesvg.org) - Open source SVG icon library with 5,600+ brand and cloud icons. Built with Next.js 15 App Router, Tailwind CSS, and Fuse.js search (GitHub: https://github.com/glincker/thesvg).
-
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.


### PR DESCRIPTION
Adds [thesvg](https://thesvg.org) to the Apps section.

Open source SVG icon library built with Next.js 15 (App Router, SSG). 5,600+ statically generated icon pages with Fuse.js search, Tailwind CSS, and shadcn/ui.

- Website: https://thesvg.org
- Source: https://github.com/glincker/thesvg
- Stack: Next.js 15, Tailwind CSS v4, shadcn/ui, Fuse.js