### PR TITLE
Add Pushduck to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
 - [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
+- [Pushduck](https://github.com/abhay-ramesh/pushduck) - Type-safe file upload library for Next.js with S3-compatible storage, React hooks, and end-to-end TypeScript support.
 
 ## Apps
 


### PR DESCRIPTION
## Description

Adding [Pushduck](https://github.com/abhay-ramesh/pushduck) to the Extensions section.

Pushduck is a type-safe file upload library for Next.js with S3-compatible storage, React hooks, and end-to-end TypeScript support. It uses presigned URLs for direct browser-to-S3 uploads (no server bandwidth used), works on Vercel Edge and Cloudflare Workers, and supports AWS S3, Cloudflare R2, DigitalOcean Spaces, and MinIO.

## Checklist

- [x] Only one item is added per PR
- [x] Added to the correct section (Extensions)
- [x] Description starts with capital letter and ends with full stop
- [x] Link is to the GitHub repository