### PR TITLE
Add Next.js 16 Agency Boilerplate to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
 - [Kaiforge Lite](https://github.com/DevxiaLabs/kaiforge-lite) - Free and open-source Next.js admin dashboard template with Tailwind CSS, dark mode, and multiple color themes.
 - [A11y Starter Kit](https://github.com/thefrontkit/a11y-starter-kit-code) - Accessibility-first Next.js starter kit with best practices for building inclusive web apps. Demo: https://a11y-starter-kit.vercel.app/
+- [Next.js 16 Agency Boilerplate](https://github.com/CemGueler01/nextjs-agency-boilerplate-docs) - Production-ready boilerplate for web agencies with App Router, Tailwind v4, and i18n.
 
 ## Extensions
 


### PR DESCRIPTION
Adding a production-ready Next.js 16 boilerplate for web agencies with App Router, Tailwind v4, and i18n.