### PR TITLE
Add Oniichan - AI manga generator built with Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
-- [Oniichan](https://oniichan.ai) - AI manga generator, OC maker, and editor built with Next.js. Create illustrated manga pages and original characters using a custom finetuned model, with panel editing and a character library.
+- [Oniichan](https://oniichan.app) - AI manga generator, OC maker, and editor built with Next.js. Create illustrated manga pages and original characters using a custom finetuned model, with panel editing and a character library.
 
 ## Books
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [Oniichan](https://oniichan.ai) - AI manga generator, OC maker, and editor built with Next.js. Create illustrated manga pages and original characters using a custom finetuned model, with panel editing and a character library.
 
 ## Books
 


### PR DESCRIPTION
Adding [Oniichan](https://oniichan.ai) to the Apps section.

Oniichan is an AI manga generator, OC maker, and editor built with Next.js. Users can create illustrated manga pages and original characters from text prompts using a custom finetuned model, with panel editing and a reusable character library.

- **Website:** https://oniichan.ai
- **Built with:** Next.js, TypeScript, Tailwind CSS, Prisma, PostgreSQL
- **Pricing:** Free tier / Pro $9.99/mo