### PR TITLE
Add MarginSafe.ai to Apps list

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [MarginSafe.ai](https://marginsafe.ai) - AI-powered stock analysis platform tailored for investors, built with Next.js.
 
 ## Books
 


### PR DESCRIPTION
Hi,

I would like to add [MarginSafe.ai](https://marginsafe.ai) to the Next.js Apps showcase list. 

MarginSafe.ai is a professional AI-driven stock analysis platform. It leverages the Next.js App Router for internationalization (i18n) and lightning-fast server-side rendering. It provides value investors with instant intrinsic value (Graham number) calculations and Wyckoff technical analysis via computer vision.

Thank you!