### PR TITLE
Add DocuPilot - AI-powered documentation auto-generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.
+- [DocuPilot](https://github.com/AkrMcmr/docupilot) - AI-powered GitHub App built with Next.js that auto-updates documentation on every push.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
 - [FIM Agent](https://github.com/fim-ai/fim-agent) - AI-powered Connector Hub with a Next.js + shadcn/ui portal frontend. Features agent management, connector configuration, knowledge base, and real-time chat with SSE streaming.
 - [FastUtil](https://fastutil.app) - 71+ free browser-based developer utilities with client-side processing, 20 language translations, and no sign-up required. Built with Next.js App Router and shadcn/ui.


### PR DESCRIPTION
## Summary

- Adds [DocuPilot](https://github.com/AkrMcmr/docupilot) to the **Apps** section.

DocuPilot is an AI-powered GitHub App built with Next.js that automatically updates project documentation (README, CHANGELOG, API docs) on every push. It leverages Next.js for its web interface and deployment on Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)