### PR TITLE
Add Mission Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [Mission Control](https://github.com/MeisnerDan/mission-control) - Cockpit for the agentic era — manage AI agent swarms with autonomous daemon, Field Ops for real-world execution, and approval workflows.
 
 ## Books
 


### PR DESCRIPTION
Everyone's building tools to create more AI agents. Almost nobody's building tools to run them.

Mission Control is the cockpit for the agentic era — a Next.js 15 App Router application where solo entrepreneurs manage their AI agent swarm with full visibility and guardrails.

The idea-to-launch flow: capture a raw idea, agents research it, build the MVP, and Field Ops launches it into the world — posting to X, deploying sites, running campaigns — with approval workflows at every step. You make three decisions. They do everything else.

**Why it's interesting as a Next.js project:**
- Next.js 15 App Router + TypeScript strict + Tailwind CSS + shadcn/ui
- - 17 UI views, 35+ API endpoints with Zod validation
- - Local-first JSON storage with async-mutex for concurrent write safety (no database)
- - Token-optimized API: ~50 tokens per request vs ~5,400 unfiltered (92% reduction)
- - 193 automated tests, 22K+ LOC
Built by a solo founder running their own agent swarm daily. 317+ stars, 30+ forks.

https://github.com/MeisnerDan/mission-control