### PR TITLE
Add HygieneScout to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Password](https://github.com/dotcypress/password) - One password, right way.
 - [Next Todos](https://github.com/lipp/next-todos) - Todo list written in Next.js.
 - [Hacker News](https://github.com/lipp/hackernews) - Another Hacker News written in Next.js.
+- [HygieneScout](https://hygienescout.co.uk) - UK food hygiene ratings for 600,000+ establishments with rating history tracking, powered by FSA open data.
 - [Jet Chat](https://github.com/lipp/jet-chat) - Jet and Next.js powered Chat demo.
 - [Nextgram](https://github.com/arunoda/nextgram) - Sample Next.js v2 app for showing off its capabilities.
 - [Rauchg Blog](https://github.com/rauchg/blog) - Blog built by a Next.js core maintainer.


### PR DESCRIPTION
## What is HygieneScout?

[HygieneScout](https://hygienescout.co.uk) is a programmatic SEO site that indexes 600,000+ UK food hygiene rated establishments, generating 650K+ pages targeting long-tail search queries.

**Tech stack:**
- Next.js 15 with App Router
- ISR (Incremental Static Regeneration) for 650K+ pages
- PostgreSQL via Drizzle ORM
- Tailwind CSS 4 + shadcn/ui
- TypeScript throughout

**Why it belongs on this list:**
- Real-world, production Next.js app serving hundreds of thousands of pages
- Demonstrates programmatic SEO at scale with Next.js App Router and ISR
- Uses FSA open data (Food Standards Agency, UK Government) with rating history tracking
- Live at [hygienescout.co.uk](https://hygienescout.co.uk)