### PR TITLE
Add ODataMap - Interactive scientific research visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [ODataMap](https://github.com/CherishChenCherish/odatamap) - Interactive scientific research data map visualizing 250M+ papers across 7 knowledge continents. Built with Next.js 16, D3.js, and OpenAlex API.
 
 ## Books
 


### PR DESCRIPTION
ODataMap is an interactive scientific research data map built with Next.js 16, D3.js, and OpenAlex API. It visualizes 250M+ papers across 7 knowledge continents and 45 research directions.

Live demo: https://odatamap.cherishchen2510.workers.dev
GitHub: https://github.com/CherishChenCherish/odatamap