### PR TITLE
Add AirwayLab to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [AirwayLab](https://airwaylab.app) - Open-source PAP therapy analysis dashboard. Processes medical device data entirely in-browser using Web Workers. Built with Next.js, TypeScript, and shadcn/ui.
 
 ## Books
 


### PR DESCRIPTION
AirwayLab is an open-source (GPL-3.0) PAP therapy analysis dashboard built with Next.js 14, TypeScript, and shadcn/ui.

It processes medical device data (CPAP/BiPAP) entirely in-browser using Web Workers -- no server-side processing required. Features include flow limitation scoring, breathing pattern analysis, and an oximetry pipeline.

- **Website:** https://airwaylab.app
- **Repository:** https://github.com/airwaylab-app/airwaylab
- **Live demo:** https://airwaylab.app/analyze?demo
- **License:** GPL-3.0
- **Stack:** Next.js, TypeScript, shadcn/ui, Web Workers, Recharts