### PR TITLE
Add QueryGPT to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [QueryGPT](https://github.com/MoonMao42/QueryGPT) - Self-hosted text-to-SQL tool with natural language queries, auto Python analysis, and chart generation.
 
 ## Books
 


### PR DESCRIPTION
Adding [QueryGPT](https://github.com/MoonMao42/QueryGPT) to the Apps section.

QueryGPT is a self-hosted text-to-SQL tool built with Next.js 15, React 19, TypeScript, Zustand, and TanStack Query on the frontend, with a FastAPI + SQLAlchemy backend. Users ask questions in natural language, get SQL + results, and optionally get Python-powered analysis and charts.

The frontend includes a schema relationship graph editor (React Flow), streaming chat UI, and a semantic layer configuration panel.