### PR TITLE
Add DevTools Hub to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 ## Apps
 
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.
+- [DevTools Hub](https://devtools-rose-kappa.vercel.app) - Collection of 30+ free AI-powered developer tools built with Next.js App Router and deployed on Vercel. Includes JSON fixer, cron expression generator, regex builder, README generator, and more.
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
 - [FIM Agent](https://github.com/fim-ai/fim-agent) - AI-powered Connector Hub with a Next.js + shadcn/ui portal frontend. Features agent management, connector configuration, knowledge base, and real-time chat with SSE streaming.


### PR DESCRIPTION
## Summary

Adding [DevTools Hub](https://devtools-rose-kappa.vercel.app) to the Apps section.

DevTools Hub is a collection of 30+ free AI-powered developer tools built with Next.js App Router and deployed on Vercel. It includes tools like:
- AI-powered JSON fixer
- Cron expression generator
- Regex builder
- README generator
- JWT decoder, Base64, Hash generator, and more

Placed alphabetically in the Apps section alongside similar developer tool apps like DevToolKit and FastUtil.