### PR TITLE
Add SBTI - Satirical Personality Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [SBTI](https://sbti.support) - A satirical personality test parodying MBTI with 27 hilarious types. Built with Next.js App Router, i18n (EN/ZH/JA/KO), and static export. 100% free, no login.
 
 ## Books
 


### PR DESCRIPTION
## Add: SBTI - Satirical Behavior Type Indicator

**Link:** https://sbti.support

**Description:** A satirical personality test parodying MBTI with 27 hilarious types. Built with Next.js App Router, i18n (EN/ZH/JA/KO), and static export. 100% free, no login.

**Tech stack:** Next.js 15, App Router, next-intl, Tailwind CSS, shadcn/ui, Cloudflare Pages

**Features:**
- 30-question quiz with 15-dimension personality analysis
- 27 unique personality types with witty descriptions
- Multi-language support (English, Chinese, Japanese, Korean)
- SEO optimized with structured data (Quiz + Article schema)
- Static export for fast loading