### PR TITLE
Add Forge to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [FIM Agent](https://github.com/fim-ai/fim-agent) - AI-powered Connector Hub with a Next.js + shadcn/ui portal frontend. Features agent management, connector configuration, knowledge base, and real-time chat with SSE streaming.
 - [FastUtil](https://fastutil.app) - 71+ free browser-based developer utilities with client-side processing, 20 language translations, and no sign-up required. Built with Next.js App Router and shadcn/ui.
 - [Feednext](https://github.com/feednext/feednext) - An open source social media application.
+- [Forge](https://forge-web.rebaselabs.online) - AI-powered full-stack app creator with BYOK (bring your own API key). Multi-stage pipeline with planning, architecture, code generation, and verification. SSR-first Next.js App Router.
 - [NextJS GOT](https://github.com/auth0-blog/nextjs-got) - Simple Next.js application that showcases Game of Thrones Characters.
 - [Relate](https://github.com/RelateNow/relate) - Mindfulness community - React, GraphQL, Next.js.
 - [Password](https://github.com/dotcypress/password) - One password, right way.


### PR DESCRIPTION
Add [Forge](https://forge-web.rebaselabs.online) — an AI-powered full-stack app creator built with Next.js App Router.

- **URL:** https://forge-web.rebaselabs.online
- **GitHub:** https://github.com/sudo-rebase/forge
- **Description:** AI-powered full-stack app creator with BYOK (bring your own API key). Multi-stage pipeline with planning, architecture, code generation, and verification. SSR-first Next.js App Router.

Forge is built with Next.js and also generates Next.js applications.