### PR TITLE
Add Rollgate to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
 
+- [Rollgate](https://rollgate.io) - Feature flag management SaaS with scheduled releases, instant rollback, gradual rollouts and A/B testing. Dashboard built with Next.js 14 App Router, Server Components and Tailwind.
+
 ## Books
 
 - [Hands On Next.js](https://leanpub.com/hands-on-nextjs) - A practical fullstack book on universal (server) rendering for react applications.


### PR DESCRIPTION
Adds [Rollgate](https://rollgate.io) to the Apps section.

Rollgate is a feature flag management SaaS. The dashboard is built with Next.js 14 (App Router), Server Components for marketing/SEO pages, and Tailwind. It's a real-world production app showcasing Next.js patterns: domain split (marketing vs app subdomain), Server Component hydration, middleware auth, and SSE streaming.

- Website: https://rollgate.io
- Dashboard: https://app.rollgate.io