### PR TITLE
Add Next.js Landing Page Template to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Next & Vercel Typescript template](https://github.com/alepacheco/landing-template) - Serverless, Typescript, Jest, Github CI, SCSS, prettier boilerplate
 - [NextJS in Firebase with Bootstrap](https://github.com/ananddayalan/nextjs-in-firebase-with-bootstrap) - Hosting NextJS app with Bootstrap in Firebase with Cloud Functions.
 - [Next Simple Starter](https://github.com/ooade/NextSimpleStarter) - Simple PWA boilerplate with Next.js and Redux.
+- [Next.js Landing Page Template](https://github.com/R3D-SH3LL/nextjs-landing-template) - Production-ready landing page template with Next.js 16, TypeScript, Tailwind CSS 4, and shadcn/ui. Responsive design, dark mode, and 95+ Lighthouse scores.
 - [NextJS Starter](https://github.com/iaincollins/nextjs-starter) - Starter project for Next.js with and email and oAuth authentication.
 - [nextjs-starter](https://github.com/pbteja1998/nextjs-starter) - An SEO Optimized Next.js 10 starter kit template with React 17 + Typescript + Tailwind CSS 2 + React Query 3 + (GitHub Auth + Passwordless Auth) using (NextAuth.js and Fauna DB), ESLint, Prettier, Pre-commit hook with Husky. Can have different layouts for different pages.
 - [RAN!](https://github.com/sly777/ran) - Production-ready boilerplate with support for GraphQL, SSR, Hot-reload, CSS-in-JS, caching, and more.


### PR DESCRIPTION
Adding a production-ready Next.js landing page template to the Boilerplates section.

**Repository:** https://github.com/R3D-SH3LL/nextjs-landing-template

**Tech Stack:** Next.js 16, TypeScript, Tailwind CSS 4, shadcn/ui

**Features:**
- Hero, Services, About, Testimonials, CTA, Contact sections
- Responsive design (mobile, tablet, desktop)
- Dark mode toggle
- 95+ Lighthouse scores
- Easy customization via CSS variables
- MIT licensed