### PR TITLE
Add ShopSavvy Vercel AI SDK Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
 - [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
+- [ShopSavvy Vercel AI SDK Tools](https://github.com/shopsavvy/vercel-ai-shopsavvy) - Vercel AI SDK tools for product search and price comparison across thousands of retailers.
 
 ## Apps
 


### PR DESCRIPTION
Adds [ShopSavvy Vercel AI SDK Tools](https://github.com/shopsavvy/vercel-ai-shopsavvy) to the Extensions section — Vercel AI SDK tools that give any LLM access to product search and price comparison across thousands of retailers.