### PR TITLE
Add FmtDev to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
 - [FIM Agent](https://github.com/fim-ai/fim-agent) - AI-powered Connector Hub with a Next.js + shadcn/ui portal frontend. Features agent management, connector configuration, knowledge base, and real-time chat with SSE streaming.
 - [FastUtil](https://fastutil.app) - 71+ free browser-based developer utilities with client-side processing, 20 language translations, and no sign-up required. Built with Next.js App Router and shadcn/ui.
+- [FmtDev](https://fmtdev.dev/tools/rsc-payload-decoder) - A 100% offline, client-side visualizer and debugger for React Server Component (RSC) payloads.
 - [Feednext](https://github.com/feednext/feednext) - An open source social media application.
 - [NextJS GOT](https://github.com/auth0-blog/nextjs-got) - Simple Next.js application that showcases Game of Thrones Characters.
 - [Relate](https://github.com/RelateNow/relate) - Mindfulness community - React, GraphQL, Next.js.


### PR DESCRIPTION
Hi @unicodeveloper,
I noticed the Apps list is growing but currently lacks tools specifically built for debugging the new App Router and React Server Components (RSC).
I've built an open-source-friendly, 100% client-side Next.js app called FmtDev featuring an RSC Payload Decoder. It allows developers to paste raw text/x-component flight data streams from their network tab and visually inspect the tree to prevent data leaks.
Why it fits: It runs completely offline with zero server logs, making it safe for developers to debug production Next.js payloads without leaking sensitive database records or API keys. I added it under the Apps section right next to similar dev tools.
Thank you for maintaining this awesome resource!