### PR TITLE
Add CIPHER x402 Paywall (x402 HTTP 402 payment demo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [CIPHER x402 Paywall](https://cipher-x402.vercel.app) - Live Next.js demo of the x402 HTTP 402 payment protocol: 4 chapters gated behind pay-per-request USDC micropayments, no accounts or API keys. Deployed on Vercel.
 
 ## Books
 


### PR DESCRIPTION
Adding [CIPHER x402 Paywall](https://cipher-x402.vercel.app) to the **Apps** section.

It's a live Next.js demo of the x402 HTTP 402 payment protocol — four content chapters gated behind pay-per-request USDC micropayments, no accounts or API keys needed. Deployed on Vercel.

Happy to move to a different section or reformat if it fits better elsewhere.