### PR TITLE
Add FractalCycles (market cycle detection, Next.js 14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [FractalCycles](https://fractalcycles.com) - Market cycle detection platform using signal processing (Goertzel DFT, Bartels significance testing, Hurst exponent). Built with Next.js 14 App Router, TanStack Query, and Tailwind.
 
 ## Books
 


### PR DESCRIPTION
Adds [FractalCycles](https://fractalcycles.com) to the Apps section.

A platform for detecting statistically validated cycles in financial market data. Frontend is Next.js 14 (App Router) with TanStack Query for server state, Zustand for client state, shadcn/ui on Radix primitives, and Recharts / TradingView Lightweight Charts for visualisation.

Free tier available; no login required to browse the SEO content pages and interactive tools (e.g. [Hurst calculator](https://fractalcycles.com/tools/hurst-calculator)).

Entry is formatted to match existing Apps section lines (single bullet, short description ending with period, Next.js stack called out).