### PR TITLE
Add @mostajs/orm — 13-database ORM for Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
 - [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
+- [@mostajs/orm](https://github.com/apolocine/mosta-orm) - Plug & Play ORM for Next.js with 13 databases. Bundler-friendly, lazy-loaded dialects, Prisma bridge included.
 
 ## Apps
 


### PR DESCRIPTION
[@mostajs/orm](https://github.com/apolocine/mosta-orm) — Plug & Play ORM with 13 database backends (SQLite, PostgreSQL, MySQL, MongoDB, Oracle, SQL Server, etc.). Bundler-friendly with lazy-loaded dialects — safe for Next.js without serverExternalPackages. Includes a Prisma bridge for zero-rewrite migration.