### PR TITLE
Add glot.it under Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [FIM Agent](https://github.com/fim-ai/fim-agent) - AI-powered Connector Hub with a Next.js + shadcn/ui portal frontend. Features agent management, connector configuration, knowledge base, and real-time chat with SSE streaming.
 - [FastUtil](https://fastutil.app) - 71+ free browser-based developer utilities with client-side processing, 20 language translations, and no sign-up required. Built with Next.js App Router and shadcn/ui.
 - [Feednext](https://github.com/feednext/feednext) - An open source social media application.
+- [glot.it](https://glot.it) — Free Thai-language learning PWA in Next.js 16 + React 19. 161 lessons, pitch-contour pronunciation scoring, AI roleplay chat, offline-first. Source: [github.com/kensaurus/glot.it](https://github.com/kensaurus/glot.it).
 - [NextJS GOT](https://github.com/auth0-blog/nextjs-got) - Simple Next.js application that showcases Game of Thrones Characters.
 - [Relate](https://github.com/RelateNow/relate) - Mindfulness community - React, GraphQL, Next.js.
 - [Password](https://github.com/dotcypress/password) - One password, right way.


### PR DESCRIPTION
## What

Adds [glot.it](https://glot.it) — a free open-source Thai-learning PWA with pitch-contour pronunciation scoring — to the relevant section.

## Why it fits

- Real production app (not a template or boilerplate)
- Source code public: https://github.com/kensaurus/glot.it
- Live demo: https://glot.it
- iOS + Android via Capacitor from the same codebase
- 106K LOC TypeScript, 177 Supabase migrations, 47 Edge Functions

## Checklist

- [x] Entry is alphabetized within its section
- [x] Description is under 240 chars
- [x] Includes both repo link and live URL
- [x] No emojis in entry