### PR TITLE
Add create-next-shadcn-kit to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 ## Boilerplates
 
+- [create-next-shadcn-kit](https://github.com/NikunjSonigara/create-next-shadcn-kit) - Interactive CLI to create a production-ready Next.js app with shadcn/ui, Tailwind CSS, and optional state management (Redux/Zustand) in one command.
 - [Kaiforge Lite](https://github.com/DevxiaLabs/kaiforge-lite) - Free admin dashboard template with Next.js 14, Tailwind CSS, TypeScript, dark/light mode, and 5 ready-to-use pages. MIT licensed. [Demo](https://lite.kaiforge.dev)
 - [Kaminari Template](https://kaminari.vercel.app/) - Power packed Next.js and Tailwind CSS template. Built with developer experience in mind. Contains Husky, CommitLint, Prettier, Eslint etc. configs. ✨
 - [Next.js, Strapi Portfolio Starter](https://github.com/PictureElement/nextjs-strapi-portfolio-starter) – ⚡️ A modern portfolio starter with Next.js, Strapi, and Tailwind CSS, featuring automated XML sitemap, JSON-LD schemas, OpenGraph metadata, and a contact form with spam protection.


### PR DESCRIPTION
Adds create-next-shadcn-kit, a CLI to scaffold Next.js apps with Tailwind CSS and shadcn/ui preconfigured, to the Boilerplates section.

Happy to update or remove if it doesn't meet the contribution guidelines.