### PR TITLE
Add shieldcn

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
 - [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
+- [shieldcn](https://github.com/jal-co/shieldcn) - Shields.io alternative that renders badges as shadcn/ui Button components via Satori. Built with Next.js 16, React 19, and Tailwind CSS v4.
 
 ## Apps
 


### PR DESCRIPTION
[shieldcn](https://github.com/jal-co/shieldcn) is a shields.io alternative built with Next.js 16 that renders GitHub README badges as actual shadcn/ui Button components via Satori.

**Website:** https://shieldcn.dev

It uses Next.js route handlers (`app/[...slug]/route.ts`) to parse badge URLs, fetch data from providers (npm, GitHub, Discord, Reddit), and render React components to SVG/PNG via Satori. Built with React 19, Tailwind CSS v4, and Fumadocs for documentation.

- [x] Searched previous suggestions — no duplicate found.
- [x] Uses the format: `[Title Case Name](link) - Description.`
- [x] Description starts with uppercase, ends with period.
- [x] Spelling and grammar checked.