### PR TITLE
Add VibeXForge to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [VibeXForge](https://github.com/alex-jb/vibex) - Source-available AI launch platform; Claude-scored project reviews and RPG-style evolution on engagement metrics.
 
 ## Books
 


### PR DESCRIPTION
Adding VibeXForge to the `## Apps` section.

**What it does**: AI-native launch platform built on Next.js 16. Users submit a URL or GitHub repo, get a Claude Haiku 4.5 review across 5 dimensions (originality, clarity, UX potential, virality potential, investor curiosity), and the project becomes a 16-bit pixel-art "hero card" that evolves through 6 RPG stages on real engagement (plays / upvotes / shares).

**Why it fits Apps**: production Next.js 16 application using Cache Components, RSC, Server Actions. Source-available on GitHub, runs locally with `npm run dev` in 30 seconds (mock data baked in, no API keys required). Live at [vibexforge.com](https://www.vibexforge.com).

**Tech notes**: Next.js 16 (App Router + Turbopack) · Supabase (Auth / RLS / SECURITY DEFINER RPCs) · Claude API direct · Remotion-driven trailer pipeline · Bilingual EN/ZH (~925 i18n strings). Open beta, 109 commits in the past 2 weeks.

Happy to adjust description length or section per your preference.