### PR TITLE
Add User Tour Kit to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
 - [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
+- [User Tour Kit](https://github.com/domidex01/tour-kit) - Headless onboarding library with first-class Next.js App Router adapter — RSC-aware, supports route-aware tours, hints, checklists, and announcements.
 
 ## Apps
 


### PR DESCRIPTION
Adding [User Tour Kit](https://github.com/domidex01/tour-kit) to the Extensions section.

User Tour Kit ships a first-class Next.js App Router adapter — route-aware tours, RSC-compatible client wrappers, and dynamic step targeting via `useSelectedLayoutSegment`. It's a modular onboarding suite (tours, hints, checklists, microsurveys, announcements) — all headless and TypeScript-first.

Repo: https://github.com/domidex01/tour-kit
Docs: https://usertourkit.com (built with Fumadocs on Next.js)