### PR TITLE
Add Portfolio Template to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
 - [Kaiforge Lite](https://github.com/DevxiaLabs/kaiforge-lite) - Free and open-source Next.js admin dashboard template with Tailwind CSS, dark mode, and multiple color themes.
 - [A11y Starter Kit](https://github.com/thefrontkit/a11y-starter-kit-code) - Accessibility-first Next.js starter kit with best practices for building inclusive web apps. Demo: https://a11y-starter-kit.vercel.app/
+- [Portfolio Template](https://github.com/miss-kniz/folio-config) - Open-source developer portfolio built with Next.js, TypeScript, and Tailwind CSS. SEO-optimized and ready to deploy.
 
 ## Extensions
 


### PR DESCRIPTION
I'd like to contribute my open-source portfolio template to the list.
Why it's a good fit:
Built with Next.js + TypeScript + Tailwind CSS.
Focuses heavily on SEO and performance out-of-the-box.
Fully customizable via a single config file for quick reuse.
I believe it would be a valuable resource for developers looking to ship a high-performance portfolio quickly.