### PR TITLE
Add Pyanchor to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [ogimg.xyz](https://ogimg.xyz) - OG image generation API with 10 templates, background patterns, and URL auto-fetch. Built with Next.js + Satori on Vercel Edge.
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
 - [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.
+- [Pyanchor](https://github.com/pyanchor/pyanchor) - Self-hosted live-edit sidecar for Next.js — click an element, describe a change in plain text, and a pluggable AI agent (Codex / Claude / Aider / Gemini / Pollinations) edits the source, builds, and reloads or opens a PR. MIT.
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
 
 ## Apps


### PR DESCRIPTION
Adds Pyanchor (https://github.com/pyanchor/pyanchor) to the Extensions section.

Pyanchor is a self-hosted Express sidecar for Next.js that lets non-frontend collaborators (designers, PMs, backend devs) make small UI changes by clicking elements in the running app and describing the change in plain language. An AI agent (Codex / Claude / Aider / Gemini / Pollinations — pluggable via one env var) edits the source, runs the build, and either reloads the dev server or opens a PR for review.

Most users so far are on the Next.js app router. Conceptually adjacent to Frontman (already listed) — Pyanchor is the sidecar/PR-mode flavor of the same idea. MIT, ~2 runtime deps.