### PR TITLE
Add Vizz.fm to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [Vizz.fm](https://vizz.fm) - Browser-based music visualizer built with Next.js, Three.js, and the Web Audio API.
 
 ## Books
 


### PR DESCRIPTION
vizz.fm is a free browser-based music visualizer with dozens of variants. Connect it to an audio source, customize it, and save your own presets.

- [x]  Searched previous suggestions — no duplicate found.
- [x] Uses the format: [Title Case Name](link) - Description.
- [x] Description starts with uppercase, ends with period.
- [x] Spelling and grammar checked.