### PR TITLE
Add @dualmark/nextjs to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
 - [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
+- [@dualmark/nextjs](https://github.com/dodopayments/dualmark/tree/main/packages/nextjs) - Open-source AEO (Answer Engine Optimization) infrastructure for Next.js App Router. Gives every page a markdown twin (e.g. `/pricing` + `/pricing.md`) picked by HTTP content negotiation, so ChatGPT, Claude, Perplexity, and Gemini get clean markdown while humans get HTML — same URL, two formats. Includes a `withDualmark()` config wrapper, a route handler factory, and a conformance CLI.
 
 ## Apps
 


### PR DESCRIPTION
Adds [@dualmark/nextjs](https://www.npmjs.com/package/@dualmark/nextjs) to the **Extensions** section.

**What it is:** A drop-in adapter for Next.js App Router that gives every page a markdown twin (e.g. `/pricing` + `/pricing.md`), picked by HTTP content negotiation. AI bots (GPTBot, ClaudeBot, PerplexityBot, +16 known UAs) get clean markdown; humans get HTML. Includes a `withDualmark()` config wrapper, a content-negotiation proxy, a route handler factory, and an `llms.txt` handler.

- 47 tests passing, 120/125 on its own conformance suite (`bunx @dualmark/cli verify`)
- Apache 2.0, npm provenance attested (Sigstore-signed)
- Spec is public and framework-agnostic: https://github.com/dodopayments/dualmark/tree/main/spec
- Live demo: https://dualmark.dev

Placed at the end of Extensions. Happy to adjust placement or wording.