### PR TITLE
Add OTF SaaS Dashboard Kit to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
 - [Kaiforge Lite](https://github.com/DevxiaLabs/kaiforge-lite) - Free and open-source Next.js admin dashboard template with Tailwind CSS, dark mode, and multiple color themes.
 - [A11y Starter Kit](https://github.com/thefrontkit/a11y-starter-kit-code) - Accessibility-first Next.js starter kit with best practices for building inclusive web apps. Demo: https://a11y-starter-kit.vercel.app/
+- [OTF SaaS Dashboard Kit](https://otf-kit.dev/templates/saas-dashboard) - Production SaaS template with TanStack Router, Hono, Drizzle, Better Auth, and Stripe, shipped with CLAUDE.md and .cursorrules so Claude Code and Cursor extend it like docs. Demo: https://saas.otf-kit.dev
 
 ## Extensions
 


### PR DESCRIPTION
OTF SaaS Dashboard Kit is a production Next.js + TanStack Router + Hono + Drizzle + Better Auth + Stripe template.

Demo: https://saas.otf-kit.dev · Marketing: https://otf-kit.dev/templates/saas-dashboard

Differentiator vs other boilerplates in the section: ships with battle-tested `CLAUDE.md` and `.cursorrules` plus 40+ tested prompts in `ai/prompts/` so Claude Code and Cursor extend the codebase like docs.