### PR TITLE
Add srb/ui – Next.js UI component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Twitter Clone](https://github.com/AlandSleman/t3-twitter-clone) - Twitter clone built with Next.js + T3 Stack + NextAuth + Supabase + Prisma.
 - [Taxonomy](https://github.com/shadcn/taxonomy) - An example app built using Next.js 13 server components.
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
+- [srb/ui](https://ui.srb.codes) - Production-ready UI blocks and components for Next.js apps built with shadcn/ui and Tailwind CSS.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
 


### PR DESCRIPTION
## Add srb/ui

Adding **srb/ui** — a Next.js App Router site and component registry.

- URL: https://ui.srb.codes
- Built with Next.js 16 App Router
- Component registry distributed via shadcn CLI
- Production-ready animated blocks: hero, CTA, features, testimonials
- Stack: Tailwind CSS v4, shadcn/ui, Radix UI, Framer Motion