### PR TITLE
Add OTF to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
 - [Kaiforge Lite](https://github.com/DevxiaLabs/kaiforge-lite) - Free and open-source Next.js admin dashboard template with Tailwind CSS, dark mode, and multiple color themes.
 - [A11y Starter Kit](https://github.com/thefrontkit/a11y-starter-kit-code) - Accessibility-first Next.js starter kit with best practices for building inclusive web apps. Demo: https://a11y-starter-kit.vercel.app/
+- [OTF — Open Template Forest](https://otf-kit.dev) - Production-ready full-stack Next.js kits (SaaS dashboard, fitness, more) with a free MIT cross-platform component SDK shared with Expo, pre-wired for Claude Code, Cursor, and Lovable. Live demo at https://saas.otf-kit.dev
 
 ## Extensions
 


### PR DESCRIPTION
Adds OTF (https://otf-kit.dev) — production-ready full-stack Next.js kits (SaaS dashboard, fitness, more) backed by a free MIT cross-platform component SDK shared with Expo, pre-wired for Claude Code, Cursor, and Lovable.

Why it fits this list: Next.js boilerplates section currently leans toward generic starters. OTF kits are full Next.js apps with auth, Stripe, Postgres, and a working live demo (https://saas.otf-kit.dev) — closer in spirit to the modern boilerplates devs are actually shipping in 2026.

Live demo: https://saas.otf-kit.dev
Landing: https://otf-kit.dev
Docs: https://otf-kit.dev/docs

Happy to adjust phrasing or position — let me know.

— Dave