### PR TITLE
Add dotenv2types to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [dotenv2types](https://dotenv2types.vercel.app/) - Paste a `.env` and generate a typed `env.ts` with a Zod schema, inferred TypeScript type, and a documented `.env.example`. Built with Next.js, deployed on Vercel, no sign-up.
 
 ## Books
 


### PR DESCRIPTION
Adds **dotenv2types** to the Apps section. It's a free, no-signup web app built with Next.js (deployed on Vercel) that takes a pasted `.env` and returns a typed `env.ts` with a Zod schema, inferred TypeScript type, and a documented `.env.example`.

Repo: https://github.com/SolvoHQ/dotenv2types
Live: https://dotenv2types.vercel.app/

Fits in `Apps` alongside `DevToolKit` and `FastUtil` — same shape (free browser-based dev utility built with Next.js). MIT-licensed.