### PR TITLE
Add Cal.com to Open Source Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
+- [Cal.com](https://github.com/calcom/cal.com) - Scheduling infrastructure for everyone. Built with Next.js.
 - [FIM Agent](https://github.com/fim-ai/fim-agent) - AI-powered Connector Hub with a Next.js + shadcn/ui portal frontend. Features agent management, connector configuration, knowledge base, and real-time chat with SSE streaming.
 - [FastUtil](https://fastutil.app) - 71+ free browser-based developer utilities with client-side processing, 20 language translations, and no sign-up required. Built with Next.js App Router and shadcn/ui.
 - [Feednext](https://github.com/feednext/feednext) - An open source social media application.


### PR DESCRIPTION
Added Cal.com - open-source scheduling platform. 35k+ stars.