### PR TITLE
Add WPSkins to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
 - [Kaiforge Lite](https://github.com/DevxiaLabs/kaiforge-lite) - Free and open-source Next.js admin dashboard template with Tailwind CSS, dark mode, and multiple color themes.
 - [A11y Starter Kit](https://github.com/thefrontkit/a11y-starter-kit-code) - Accessibility-first Next.js starter kit with best practices for building inclusive web apps. Demo: https://a11y-starter-kit.vercel.app/
+- [WPSkins Next.js Themes](https://wpskins.org/next) - Free directory of Next.js themes and starter templates with live demos.
 
 ## Extensions
 


### PR DESCRIPTION
Adding WPSkins.org
- Free directory of 2,800+ website themes
- Covers WordPress, Shopify, Webflow, Framer, Ghost, Hugo, Astro, and 8 more platforms
- No signups, no email walls, all sourced from official channels
- Active and growing Thanks for maintaining this awesome resource!