### PR TITLE
Add PDF Mavericks to Apps (browser-local PDF toolkit, Next.js + static export)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [PDF Mavericks](https://pdfmavericks.com/) - 40+ free browser-based PDF tools (compress, merge, split, sign, watermark, redact, OCR) with client-side processing — files never leave the device. Built with Next.js App Router and static export.
 
 ## Books
 


### PR DESCRIPTION
Adds [PDF Mavericks](https://pdfmavericks.com/) to the Apps section.

PDF Mavericks is a free, no-account toolkit of 40+ PDF tools (compress, merge, split, sign, watermark, redact, OCR, convert) that processes everything entirely in the browser — files never leave the device. Built with Next.js 15 App Router and `output: 'export'` for static deploy.

Strong fit for the Apps section alongside FastUtil and similar client-side utility apps already listed. Privacy wedge: no upload, no server, no tracking beyond anonymous usage analytics — the entire PDF pipeline runs locally via PDF.js and pdf-lib.

Happy to adjust the entry text if you'd prefer a shorter description.