### PR TITLE
Add CrawlerToll (AI-crawler middleware) to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
 
+- [CrawlerToll](https://github.com/nhrzxxw9dn-web/crawlertoll-next-js) - Next.js middleware (drop-in for `middleware.ts`) for the AI-crawler economy. Detects 30+ AI crawlers, verifies Web Bot Auth (IETF draft-meunier), applies RSL 1.0 policy, and issues HTTP 402 with a structured payment offer. Next 14+15, Edge-runtime compatible.
+
 ## Apps
 
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.


### PR DESCRIPTION
Adds [CrawlerToll](https://github.com/nhrzxxw9dn-web/crawlertoll-next-js) to the **Extensions** section.

Next.js middleware (drop-in single-function for `middleware.ts`) for the AI-crawler economy. Detects 30+ AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, etc.), verifies cryptographic bot identity via Web Bot Auth ([IETF draft-meunier-05](https://datatracker.ietf.org/doc/draft-meunier-web-bot-auth-architecture/)), applies [RSL 1.0](https://rsl.standards/) policy, and issues HTTP 402 with a structured payment offer.

```ts
// middleware.ts
export { default } from "@crawlertoll/next";
```

Next.js 14+15, Edge-runtime compatible (NextRequest + NextResponse + Web Crypto, no Node-only APIs). Apache 2.0. Same decision engine has Express, Fastify, and Hono adapters.

Happy to revise entry text or section placement.