### PR TITLE
Add ThatDevPro to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [ThatDevPro](https://www.thatdevpro.com) - Engine optimization studio site. Next.js 14 static export, hand-coded with mobile Lighthouse 80+, full Schema.org @graph, AI-citation surfaces (`llms.txt`, `aeo.json`, `entity.json`, `brand.json`), and a 26-page HTTP/HTML reference library at [/reference/](https://www.thatdevpro.com/reference/).
 
 ## Books
 


### PR DESCRIPTION
Adds [ThatDevPro](https://www.thatdevpro.com) to the Apps section.

**What it is**: A production Next.js 14 static export site for an SDVOSB veteran-owned engine optimization studio. Hand-coded (not template-derived), with engineering-focused content (175+ articles across reference and insights libraries).

**Why it fits Apps**:

- Next.js 14 App Router + static export deployment pattern
- Hand-coded HTML, no boilerplate
- Mobile Lighthouse 80+ consistently
- Full Schema.org @graph implementation (Organization + Person + Service + LocalBusiness)
- AI-citation surfaces: `/llms.txt`, `/llms-full.txt`, `/aeo.json`, `/entity.json`, `/brand.json`
- 26 canonical HTTP/HTML reference pages at `/reference/`
- 100+ framework articles at `/insights/`

Sits naturally with existing entries like 'API Status Check', 'FastUtil', and 'Rauchg Blog' (also a Next.js maintainer site).