### PR TITLE
Add Next.js + Supabase SaaS Starter to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Start UI [web]](https://github.com/BearStudio/start-ui-web) - 🚀 opinionated UI starter with TypeScript, React, NextJS, Chakra UI, tRPC, Prisma, TanStack Query, Storybook, Playwright, Formiz
 - [Kaiforge Lite](https://github.com/DevxiaLabs/kaiforge-lite) - Free and open-source Next.js admin dashboard template with Tailwind CSS, dark mode, and multiple color themes.
 - [A11y Starter Kit](https://github.com/thefrontkit/a11y-starter-kit-code) - Accessibility-first Next.js starter kit with best practices for building inclusive web apps. Demo: https://a11y-starter-kit.vercel.app/
+- [Next.js + Supabase SaaS Starter](https://github.com/Edraid/nextjs-supabase-saas-starter) - Production-ready SaaS boilerplate with auth, multi-tenant orgs, Stripe billing, and transactional emails.
+
 
 ## Extensions
 


### PR DESCRIPTION
Adds the Next.js + Supabase SaaS Starter — a production-ready boilerplate with:

- Auth: email/password + Google OAuth + forgot/reset (@supabase/ssr)
- Multi-tenant orgs with 4 roles enforced at DB level with RLS
- Stripe billing: Checkout + Billing Portal + 4 webhooks
- Transactional emails: React Email + Resend
- TypeScript strict mode + full DB types

GitHub: https://github.com/Edraid/nextjs-supabase-saas-starter
MIT licensed, free to use.