### PR TITLE
feat: add TWZRD Agent Intel — AI agent payment MCP extension for Next.js apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [next-api-decorators](https://github.com/storyofams/next-api-decorators) - Decorators to create typed Next.js API routes, with easy request validation and transformation.
 - [Vercel AI SDK](https://github.com/vercel/ai) - The AI Toolkit for TypeScript. Build AI-powered applications with React, Next.js, Vue, Svelte, and Node.js.
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit) - React UI + elegant infrastructure for AI Copilots, AI chatbots, and in-app AI agents in your Next.js apps.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring and x402 micropayment verification MCP server for AI agents on Solana. Zero-install endpoint compatible with `@modelcontextprotocol/sdk`.
 - [ogimg.xyz](https://ogimg.xyz) - OG image generation API with 10 templates, background patterns, and URL auto-fetch. Built with Next.js + Satori on Vercel Edge.
 - [ShotOG](https://github.com/nicepkg/shotog) - Dynamic OG image generation API for Next.js apps, powered by Cloudflare Workers.
 - [Frontman](https://github.com/frontman-ai/frontman) - An open-source AI coding agent that lives in your browser, enabling visual element selection and plain-English code edits with hot reload.


### PR DESCRIPTION
## Description

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Extensions** section, alongside other AI tools (Vercel AI SDK, CopilotKit).

TWZRD Agent Intel is an MCP server for AI agent trust scoring and x402 micropayment verification on Solana — useful for Next.js apps that integrate AI agents or agentic payment flows:

- **Zero-install MCP**: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
- Compatible with `@modelcontextprotocol/sdk` (TypeScript)
- **Free tools**: wallet trust scoring, agent reputation
- **Paid**: `get_trust_receipt` via HTTP 402 + USDC micropayment