### PR TITLE
Add live web search guide for Vercel AI SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [Top Next.js Admin & Dashboard Templates](https://blog.codedthemes.com/nextjs-admin-dashboard-templates/)
 - [Next.js Cheatsheet](https://blog.codedthemes.com/nextjs-cheatsheet/)
 - [A Guide to Performance Optimization with Next.js](https://www.debugbear.com/blog/nextjs-performance)
+- [Add Live Web Search to a Vercel AI SDK Agent](https://superhighway.walls.sh/guides/web-search-vercel-ai)
 
 ## Boilerplates
 


### PR DESCRIPTION
Adds a guide to the Articles section: [Add Live Web Search to a Vercel AI SDK Agent](https://superhighway.walls.sh/guides/web-search-vercel-ai)

The guide covers two ways to give a Vercel AI SDK agent live web search:
1. **MCP path** — `experimental_createMCPClient` + `Experimental_StdioMCPTransport` with a funded Base wallet (five tools: search, news, images, scrape, research — each call pays per call via x402)
2. **Typed `tool()` path** — Zod-typed `tool()` helpers wrapping a REST API with a free key

The Vercel AI SDK is already listed in Extensions; this article covers practical integration with an external real-time search API. TypeScript, Vercel AI SDK native (`tool()` + `maxSteps`).

Adheres to contribution guidelines: title-cased, Article-section format `[Title Case Name](link)`.