### PR TITLE
Create Jobs Section, Add Jobs in JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
   - [Videos](#videos)
   - [Projects(Beginner level)](#projectsbeginner-level)
   - [Newsletters](#newsletters)
+  - [Jobs](#jobs)
   - [Contributing](#contributing)
   - [License](#license)
 
@@ -273,6 +274,10 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 - [Next.js News](https://nextjsnews.com) - Monthly Next.js newsletter showcasing new and upcoming features, best articles, tools, and plugins.
 - [Next.js Notes](https://nextjsnotes.com) - Monthly Next.js and JavaScript platform news.
+
+## Jobs
+
+- [Jobs in JS](https://jobsinjs.com/nextjs-developer-jobs/) - Next.js developer jobs in the US, Canada and UK. Updated daily.
 
 ## Contributing
 


### PR DESCRIPTION
Adds a Jobs section with Jobs in JS, plus the matching Contents entry.

Free to use resource for Next.js jobs. No paywall, no account- everything is available right away. We also calculate salary medians from the live listings.

Scoped to the US, Canada and the UK. Refreshed every 24 hours.

New category rather than an existing one - Community is all official Vercel links, so a job board didn't fit there. The contributing guide says new categories are welcome.

https://jobsinjs.com/nextjs-developer-jobs/