### PR TITLE
Add Calculora to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [Calculora](https://calculora.net) - 259+ free online calculators and developer tools with 21-language internationalization, built with Next.js, TypeScript, and Tailwind CSS.
 
 ## Books
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.
+- [Calculora](https://calculora.net) - 259+ free online calculators and developer tools with 21-language internationalization, built with Next.js, TypeScript, and Tailwind CSS.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
 - [FIM Agent](https://github.com/fim-ai/fim-agent) - AI-powered Connector Hub with a Next.js + shadcn/ui portal frontend. Features agent management, connector configuration, knowledge base, and real-time chat with SSE streaming.
 - [FastUtil](https://fastutil.app) - 71+ free browser-based developer utilities with client-side processing, 20 language translations, and no sign-up required. Built with Next.js App Router and shadcn/ui.
@@ -224,7 +225,6 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
-- [Calculora](https://calculora.net) - 259+ free online calculators and developer tools with 21-language internationalization, built with Next.js, TypeScript, and Tailwind CSS.
 
 ## Books
 


### PR DESCRIPTION
Adds [Calculora](https://calculora.net) — a multilingual calculator PWA built with Next.js, to the Apps section.