### PR TITLE
Add FileFlex to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
 
 ## Apps
-
+- [FileFlex](https://github.com/armor229-ux/File-Flex) - Open-source, browser-only file converter & PDF editor built with Next.js 14, Tailwind CSS, and WASM.
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.


### PR DESCRIPTION
Added FileFlex to the Apps section.

FileFlex is an open-source, browser-only file converter and PDF editor built with Next.js 14 (App Router), TypeScript, Tailwind CSS, and WASM. All processing runs 100% client-side with zero server uploads.

- Repo: https://github.com/armor229-ux/File-Flex
- Live: https://fileflexhub.vercel.app