### PR TITLE
Add Lunidex to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [shadcn/ui](https://github.com/shadcn/ui) - Beautifully designed components that you can copy and paste into your apps.
 - [StorageBox](https://github.com/AlandSleman/StorageBox) - A Simple File Storage Service Built with Go and Next.js.
 - [Taskade](https://taskade.com/) - AI-powered workspace for teams with real-time collaboration, AI agents, project management, and workflow automation.
+- [Lunidex](https://lunidex.app) - Open-source Pokémon workspace built with Next.js, featuring a Pokédex, TCG collection tracking, team building, battle tools, quizzes, and multilingual support.
 
 ## Books
 


### PR DESCRIPTION
Lunidex is an open-source Next.js application for Pokémon reference data, TCG collection tracking, team building, battle tools, quizzes, and multilingual support. It belongs in the Apps section.