### PR TITLE
Add DevScratchpad to Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 ## Apps
 
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.
+- [DevScratchpad](https://github.com/Saad-web-spec/DevScratchPad) - Privacy-first developer scratchpad & utility suite (19+ tools) with Monaco editor and zero-server transmission. Built with Next.js 16 (App Router, Turbopack, SSG), React 19, and Tailwind CSS v4. [Demo](https://tools.saadengineer.works)
 - [DevToolKit](https://github.com/a827681306/devtoolkit) - Free online developer tools built with Next.js — JSON Formatter, JWT Decoder, Regex Tester, Base64/URL Encoder, Hash Generator.
 - [CourseLit](https://github.com/codelit/courselit) - An open source alternative to Thinkific, Teachable etc.
 - [FIM Agent](https://github.com/fim-ai/fim-agent) - AI-powered Connector Hub with a Next.js + shadcn/ui portal frontend. Features agent management, connector configuration, knowledge base, and real-time chat with SSE streaming.


### PR DESCRIPTION
Adding **DevScratchpad**, an open-source, privacy-first developer utility suite (19+ tools) built with Next.js 16 (App Router, Turbopack, SSG), React 19, and Tailwind CSS v4.