### PR TITLE
Add Reely to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
 
 ## Apps
+- [Reely](https://github.com/Vette1123/movies-streaming-platform) - Movie & TV discovery and tracker on the TMDB API — live-applying filters, ⌘K command palette, watchlist and history, installable PWA. Next.js 16 static export on Cloudflare Workers Static Assets, so Next.js never runs in production. [Demo](https://www.reely.space)
 - [FileFlex](https://github.com/armor229-ux/File-Flex) - Open-source, browser-only file converter & PDF editor built with Next.js 14, Tailwind CSS, and WASM.
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.
 - [DevScratchpad](https://github.com/Saad-web-spec/DevScratchPad) - Privacy-first developer scratchpad & utility suite (19+ tools) with Monaco editor and zero-server transmission. Built with Next.js 16 (App Router, Turbopack, SSG), React 19, and Tailwind CSS v4. [Demo](https://tools.saadengineer.works)


### PR DESCRIPTION
Adding **Reely** to the Apps section.

Reely is a movie and TV discovery and tracking app on the TMDB API: trending rails, a filter panel that applies as you move it (tri-state genre pills, rating, vote count, runtime, release year, language, age certification, streaming provider), a ⌘K command palette, watchlist and watch history, and an installable PWA.

It is a Next.js 16 App Router app shipped as a static export (`output: 'export'`) on Cloudflare Workers Static Assets, plus one hand-written Worker for search, filtering and detail ids outside the prerendered set — so Next.js does not run in production at all. Moving to that layout took Worker invocations killed on the free plan's 10 ms CPU budget from 20–46% to 0.0%.

- Source: https://github.com/Vette1123/movies-streaming-platform (MIT)
- Demo: https://www.reely.space