### PR TITLE
Add Greadme to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
 
 ## Apps
+- [Greadme](https://www.greadme.com) - Website auditing app for SEO, performance, accessibility, structured data and AI visibility, built with the Next.js App Router.
 - [Reely](https://github.com/Vette1123/movies-streaming-platform) - Movie & TV discovery and tracker on the TMDB API — live-applying filters, ⌘K command palette, watchlist and history, installable PWA. Next.js 16 static export on Cloudflare Workers Static Assets, so Next.js never runs in production. [Demo](https://www.reely.space)
 - [FileFlex](https://github.com/armor229-ux/File-Flex) - Open-source, browser-only file converter & PDF editor built with Next.js 14, Tailwind CSS, and WASM.
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.


### PR DESCRIPTION
Adds Greadme to the Apps section.

Greadme is a website auditing app for SEO, performance, accessibility, structured data and AI visibility. It is built with the Next.js App Router (React, TypeScript, Material UI) and deployed on Vercel.

Site: https://www.greadme.com

Disclosure: I built it.