### PR TITLE
Add AI Video Prompt Cheatsheet to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [@farming-labs/docs](https://github.com/farming-labs/docs) - A modern documentation framework that works. One config file, zero boilerplate.
 
 ## Apps
+- [AI Video Prompt Cheatsheet](https://github.com/the-beating-light-of-the-nail/ai-video-prompt-cheatsheet) - Camera-movement prompt reference for AI video generation: shot types and motions with copy-ready prompts, one-page zh/en. Static export on Cloudflare Workers, no server. [Demo](https://videoprompts.cdqyfdbymn.me)
 - [Reely](https://github.com/Vette1123/movies-streaming-platform) - Movie & TV discovery and tracker on the TMDB API — live-applying filters, ⌘K command palette, watchlist and history, installable PWA. Next.js 16 static export on Cloudflare Workers Static Assets, so Next.js never runs in production. [Demo](https://www.reely.space)
 - [FileFlex](https://github.com/armor229-ux/File-Flex) - Open-source, browser-only file converter & PDF editor built with Next.js 14, Tailwind CSS, and WASM.
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard tracking 2,500+ APIs and cloud services. Built with Next.js and deployed on Vercel.


### PR DESCRIPTION
Adds one entry to **Apps**.

AI video generators take camera directions, but the vocabulary lives scattered across docs and tutorials. [AI Video Prompt Cheatsheet](https://videoprompts.cdqyfdbymn.me) collects it: shot types and camera movements with copy-ready prompts, on one page in two languages (zh/en). Static export on Cloudflare Workers, same setup as Reely further down the list — no Next.js server in production.

I built and maintain the site. Repo: https://github.com/the-beating-light-of-the-nail/ai-video-prompt-cheatsheet
